### PR TITLE
fixes #6 (docker not building) and closes #5 (Gazebo RTF low)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,10 @@ ENV HHCM_FOREST_CLONE_DEFAULT_PROTO=https
 RUN forest init
 RUN echo "source $PWD/setup.bash" >> /home/user/.bashrc
 RUN forest add-recipes git@github.com:advrhumanoids/multidof_recipes.git --tag master 
+WORKDIR /home/user/concert_ws/recipes/multidof_recipes
+RUN git fetch
+RUN git pull
+WORKDIR /home/user/concert_ws
 
 # concert packages
 RUN forest grow concert_all --verbose --jobs 4 --pwd user


### PR DESCRIPTION
Wrst #6 : By adding git fetch and pull commands for the forest recipies repo to the dockerfile, the docker is building successfully.

Wrst #5 : Tested: when running the simulation using the `gpu_ray` flag for the concert gazebo launch file, point clouds can be subsribed without the gazebo RTF dropping down.